### PR TITLE
revert back to os getenv for env vars

### DIFF
--- a/imputer/tasks.py
+++ b/imputer/tasks.py
@@ -27,12 +27,12 @@ from openhumansimputer.celery import app
 
 
 HOME = environ.get('HOME')
-IMP_BIN = environ.get('IMP_BIN')
-REF_PANEL = environ.get('REF_PANEL')
-REF_PANEL_X = environ.get('REF_PANEL_X')
-DATA_DIR = environ.get('DATA_DIR')
-REF_FA = environ.get('REF_FA')
-OUT_DIR = environ.get('OUT_DIR')
+IMP_BIN = settings.IMP_BIN
+REF_PANEL = settings.REF_PANEL
+REF_PANEL_X = settings.REF_PANEL_X
+DATA_DIR = settings.DATA_DIR
+REF_FA = settings.REF_FA
+OUT_DIR = settings.OUT_DIR
 
 # Set up logging.
 logger = logging.getLogger('oh')

--- a/openhumansimputer/settings.py
+++ b/openhumansimputer/settings.py
@@ -242,11 +242,12 @@ INSTALLED_APPS += ['django_extensions']
 CELERY_BROKER_URL = os.getenv('CELERY_BROKER_URL')
 # Directory config, change these if you have a different setup.
 # Also make sure these are in /etc/default/celeryd
-IMP_BIN = os.path.join(BASE_DATA_DIR, os.getenv('IMP_BIN'))
-REF_PANEL = os.path.join(BASE_DATA_DIR, os.getenv('REF_PANEL'))
-DATA_DIR = os.path.join(BASE_DATA_DIR, os.getenv('DATA_DIR'))
-REF_FA = os.path.join(BASE_DATA_DIR, os.getenv('REF_FA'))
-OUT_DIR = os.path.join(BASE_DATA_DIR, os.getenv('OUT_DIR'))
+IMP_BIN = os.getenv('IMP_BIN')
+REF_PANEL = os.getenv('REF_PANEL')
+REF_PANEL_X = os.getenv('REF_PANEL_X')
+DATA_DIR = os.getenv('DATA_DIR')
+REF_FA = os.getenv('REF_FA')
+OUT_DIR = os.getenv('OUT_DIR')
 
 # Sentry
 sentry_sdk.init(


### PR DESCRIPTION
`source .env` before starting the app (and celery worker) gets the app to run smoothly start to finish.
@jhdulaney Do these changes impede any of the progress you made?