### PR TITLE
make login_required for the launch imputation view

### DIFF
--- a/main/views.py
+++ b/main/views.py
@@ -149,6 +149,7 @@ def complete(request):
     return redirect('/')
 
 
+@login_required(login_url="/")
 def launch_imputation(request):
     """
     Logic to check whether user exists:


### PR DESCRIPTION
Whenver you hit the following error:
AttributeError: 'AnonymousUser' object has no attribute 'oh_member'
it means that you are expecting a logged in user, but are not getting it.  The fix is to add the 
@login_required decorator.



Signed-off-by: Mairi Dulaney <jdulaney@fedoraproject.org>